### PR TITLE
Add `asprintf()`

### DIFF
--- a/unistd/unistd.cpp
+++ b/unistd/unistd.cpp
@@ -579,3 +579,11 @@ int vasprintf(char **ptr, const char *format, va_list arg)
 	*ptr = p;
 	return rv;
 }
+
+int asprintf(char **ret, const char *format, ...)
+{	va_list ap;
+	va_start(ap, format);
+	int retval = vasprintf(strp, format, ap);
+	va_end(ap);
+	return retval;
+}

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -167,6 +167,7 @@ CFUNC char* strptime(const char* s, const char* format,struct tm* tm);
 CFUNC ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
 CFUNC int setlinebuf(FILE *stream);
 CFUNC int vasprintf(char **strp, const char *fmt, va_list ap);
+CFUNC int aprintf(char **ret, const char *format, ...);
 
 
 //#define strlen unistd_safe_strlen


### PR DESCRIPTION
Add an implementation of `asprintf`. The implementation of `vasprintf` already exists, so this just adds the wrapper version of it. This function is a POSIX method, not part of the C standard. It's defined on all of our other platforms but not on Windows. This makes the changes in https://github.com/zeek/zeek/pull/3137 smaller.