### PR TITLE
poll.h: Remove _MSC_VER condition

### DIFF
--- a/unistd/sys/poll.h
+++ b/unistd/sys/poll.h
@@ -5,7 +5,6 @@
 #ifndef sys_poll_h
 #define sys_poll_h
 
-#if _MSC_VER <= 1900
 #include <unistd.h>
 
 typedef WSAPOLLFD pollfd;
@@ -16,5 +15,4 @@ int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {	return WSAPoll(fds,nfds,timeout);
 }
 
-#endif
 #endif


### PR DESCRIPTION
We're using MSVC 14.29.30133 and poll() is not available. Include the WSAPoll wrapper providing poll() unconditionally.


Reference: zeek/zeek#3328