### PR TITLE
sys_types.h: Use ssize_t from basetsd.h

### DIFF
--- a/unistd/sys/sys_types.h
+++ b/unistd/sys/sys_types.h
@@ -15,11 +15,17 @@ typedef int sigval_t;
 typedef int sigset_t;
 typedef unsigned short ushort;
 typedef	int key_t;
-typedef int ssize_t;
 typedef unsigned short mode_t;
 typedef int gid_t;
 typedef int uid_t;
 typedef int Atom;
+
+#if defined(_MSC_VER)
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#else
+typedef int ssize_t;
+#endif
 
 #ifndef _WINSOCK2API_
 // Winsock2 already defines these typedefs.


### PR DESCRIPTION
Taken from there: https://stackoverflow.com/a/35368387

This is close to what the IXWebSocket library does to get a typedef for ssize and to prevent errors of disagreeing typedefs.