### PR TITLE
Fix some issues building with newer versions of VS 2022

### DIFF
--- a/regex/regex.cpp
+++ b/regex/regex.cpp
@@ -42,9 +42,7 @@ const std::map<error_type, int> ERROR_TYPE =
 	{error_space, REG_ESPACE},
 	{error_badrepeat, REG_BADRPT},
 	{error_complexity, REG_ESIZE},
-	{error_stack, REG_ESIZE},
-	{error_parse, REG_BADPAT},
-	{error_syntax, REG_BADPAT}
+	{error_stack, REG_ESIZE}
 };
 
 int getErrorCode(error_type err)

--- a/unistd/unistd.cpp
+++ b/unistd/unistd.cpp
@@ -583,7 +583,7 @@ int vasprintf(char **ptr, const char *format, va_list arg)
 int asprintf(char **ret, const char *format, ...)
 {	va_list ap;
 	va_start(ap, format);
-	int retval = vasprintf(strp, format, ap);
+	int retval = vasprintf(ret, format, ap);
 	va_end(ap);
 	return retval;
 }


### PR DESCRIPTION
`error_parse` and `error_syntax` are not part of `std::regex:error_type`, but were supported by previous versions of Visual Studio. They're removed in VS 2022 and cause the build to fail.