### PR TITLE
Remove redefinition of 'write' to avoid collisions with std::fstream::write

### DIFF
--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -234,6 +234,7 @@ CFUNC int aprintf(char **ret, const char *format, ...);
 #undef Yield
 #undef CompareString
 #undef NO_ERROR
+#undef write
 
 #if _MSC_VER < 1930
 // Workaround negative character values that caused asserts on VS 2019 and below


### PR DESCRIPTION
This came up during the work to get C++20 building. It seems sorta silly to define this and then immediately undef it, but it's following the existing pattern with some of the other symbols like `close`. This can probably go in before all of the other C++20 work since it's self-contained.