### PR TITLE
Add methods needed by zeek-cut

### DIFF
--- a/unistd/getline.cpp
+++ b/unistd/getline.cpp
@@ -1,0 +1,53 @@
+// getline.c
+// Created by Robin Rowe 2024-10-05
+// Open Source MIT
+
+#include <string.h>
+#include <memory.h>
+#include "unistd.h"
+
+#define BUFSIZE 256
+
+ssize_t getline(char** buf, size_t* bufsiz, FILE* fp)
+{	return getdelim(buf, bufsiz, '\n', fp);
+}
+
+ssize_t getdelim(char** buf, size_t* bufsiz, int delimiter, FILE* fp)
+{	if (!*buf || !*bufsiz ) 
+	{	*bufsiz = BUFSIZE;
+		*buf = (char*) malloc(*bufsiz);
+		if(!buf)
+		{	return -1;
+	}	}
+	char* ptr = *buf;
+	char* eptr = *buf + *bufsiz;
+	for(;;) 
+	{	const int c = fgetc(fp);
+		if (c == -1) 
+		{	if (feof(fp))
+			{	return ptr == *buf ? -1 : ptr - *buf;
+			}
+			return -1;
+		}
+		*ptr++ = c;
+		if (c == delimiter) 
+		{	*ptr = '\0';
+			return ptr - *buf;
+		}
+		if (ptr + 2 >= eptr) 
+		{	char* nbuf;
+			size_t nbufsiz = *bufsiz * 2;
+			ssize_t d = ptr - *buf;
+			nbuf = (char*) realloc(*buf, nbufsiz);
+			if (!nbuf)
+			{	return -1;
+			}
+			*buf = nbuf;
+			*bufsiz = nbufsiz;
+			eptr = nbuf + nbufsiz;
+			ptr = nbuf + d;
+		}
+	}
+	return -1;
+}
+

--- a/unistd/getopt.cpp
+++ b/unistd/getopt.cpp
@@ -1,9 +1,10 @@
 /* NetBSD getopt.c   */
 
-#include <string.h>
-#include <stdio.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
 
 inline
 const char* _getprogname()
@@ -14,7 +15,7 @@ int opterr = 1;		/* if error message should be printed */
 int optind = 1;		/* index into parent argv vector */
 int optopt = 0;			/* character checked for validity */
 int optreset = 0;		/* reset getopt */
-const char	*optarg = "";		/* argument associated with option */
+const char* optarg = "";		/* argument associated with option */
 
 #define	BADCH	(int)'?'
 #define	BADARG	(int)':'
@@ -98,3 +99,436 @@ getopt(int nargc,char * const nargv[],const char *ostr)
 	return (optopt);			/* return option letter */
 }
 
+#if 0
+#include <nbcompat/assert.h>
+#include <nbcompat/err.h>
+#include <errno.h>
+#include <nbcompat/getopt.h>
+#include <nbcompat/stdlib.h>
+#include <nbcompat/string.h>
+#endif
+
+#undef __UNCONST
+#if 0
+#define __UNCONST(a)	((char *)(size_t)(const void *)(a))
+#else
+#define __UNCONST(a) (a)
+#endif
+#define IGNORE_FIRST	(*options == '-' || *options == '+')
+#define PRINT_ERROR	((opterr) && ((*options != ':') \
+				      || (IGNORE_FIRST && options[1] != ':')))
+#define IS_POSIXLY_CORRECT (getenv("POSIXLY_CORRECT") != NULL)
+#define PERMUTE         (!IS_POSIXLY_CORRECT && !IGNORE_FIRST)
+/* XXX: GNU ignores PC if *options == '-' */
+#define IN_ORDER        (!IS_POSIXLY_CORRECT && *options == '-')
+
+/* return values */
+#define	BADCH	(int)'?'
+#define INORDER (int)1
+
+#define	EMSG	""
+
+static int getopt_internal(int, char**, const char*);
+static int gcd(int, int);
+static void permute_args(int, int, int, char**);
+
+static const char* place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+
+	return b;
+}
+
+#define _DIAGASSERT assert
+#define warnx printf
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(int panonopt_start, int panonopt_end, int opt_end, char** nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char* swap;
+
+	_DIAGASSERT(nargv != NULL);
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end + i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			nargv[pos] = nargv[cstart];
+			nargv[cstart] = swap;
+		}
+	}
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ *  Returns -2 if -- is found (can be long option or end of options marker).
+ */
+static int
+getopt_internal(int nargc, char** nargv, const char* options)
+{
+	char* oli;				/* option letter list index */
+	int optchar;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+
+	optarg = NULL;
+
+	/*
+	 * XXX Some programs (like rsyncd) expect to be able to
+	 * XXX re-initialize optind to 0 and have getopt_long(3)
+	 * XXX properly function again.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = 1;
+
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+					optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return -1;
+		}
+		if ((*(place = nargv[optind]) != '-')
+			|| (place[1] == '\0')) {    /* found non-option */
+			place = EMSG;
+#pragma warning(disable:4996)
+			if (IN_ORDER) {
+				/*
+				 * GNU extension:
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return INORDER;
+			}
+			if (!PERMUTE) {
+				/*
+				 * if no permutation wanted, stop parsing
+				 * at first non-option
+				 */
+				return -1;
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+					optind, nargv);
+				nonopt_start = optind -
+					(nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+		if (place[1] && *++place == '-') {	/* found "--" */
+			place++;
+			return -2;
+		}
+	}
+	if ((optchar = (int)*place++) == (int)':' ||
+		(oli = (char*) strchr(options + (IGNORE_FIRST ? 1 : 0), optchar)) == NULL) {
+		/* option letter unknown or ':' */
+		if (!*place)
+			++optind;
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+		optopt = optchar;
+		return BADCH;
+	}
+	if (optchar == 'W' && oli[1] == ';') {		/* -W long-option */
+		/* XXX: what if no long options provided (called by getopt)? */
+		if (*place)
+			return -2;
+
+		if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+			optopt = optchar;
+			return BADARG;
+		}
+		else				/* white space */
+			place = nargv[optind];
+		/*
+		 * Handle -W arg the same as --arg (which causes getopt to
+		 * stop parsing).
+		 */
+		return -2;
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	}
+	else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = __UNCONST(place);
+		/* XXX: disable test for :: if PC? (GNU doesn't) */
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+				optopt = optchar;
+				return BADARG;
+			}
+			else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return optchar;
+}
+
+#ifdef REPLACE_GETOPT
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the real getopt]
+ */
+int
+getopt(nargc, nargv, options)
+int nargc;
+char* const* nargv;
+const char* options;
+{
+	int retval;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+
+	retval = getopt_internal(nargc, __UNCONST(nargv), options);
+	if (retval == -2) {
+		++optind;
+		/*
+		 * We found an option (--), so if we skipped non-options,
+		 * we have to permute.
+		 */
+		if (nonopt_end != -1) {
+			permute_args(nonopt_start, nonopt_end, optind,
+				nargv);
+			optind -= nonopt_end - nonopt_start;
+		}
+		nonopt_start = nonopt_end = -1;
+		retval = -1;
+	}
+	return retval;
+}
+#endif
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long(int nargc, char* const* nargv, const char* options,
+	const struct option* long_options, int* idx)
+{
+	int retval;
+
+#define IDENTICAL_INTERPRETATION(_x, _y)				\
+	(long_options[(_x)].has_arg == long_options[(_y)].has_arg &&	\
+	 long_options[(_x)].flag == long_options[(_y)].flag &&		\
+	 long_options[(_x)].val == long_options[(_y)].val)
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+	_DIAGASSERT(long_options != NULL);
+	/* idx may be NULL */
+
+	retval = getopt_internal(nargc,(char**) __UNCONST(nargv), options);
+	if (retval == -2) {
+		char* current_argv, * has_equal;
+		size_t current_argv_len;
+		int i, ambiguous, match;
+
+		current_argv = (char*) __UNCONST(place); //bug?
+		match = -1;
+		ambiguous = 0;
+
+		optind++;
+		place = EMSG;
+
+		if (*current_argv == '\0') {		/* found "--" */
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+					optind,(char**) __UNCONST(nargv));
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return -1;
+		}
+		if ((has_equal = strchr(current_argv, '=')) != NULL) {
+			/* argument found (--option=arg) */
+			current_argv_len = has_equal - current_argv;
+			has_equal++;
+		}
+		else
+			current_argv_len = strlen(current_argv);
+
+		for (i = 0; long_options[i].name; i++) {
+			/* find matching long option */
+			if (strncmp(current_argv, long_options[i].name,
+				current_argv_len))
+				continue;
+
+			if (strlen(long_options[i].name) ==
+				(unsigned)current_argv_len) {
+				/* exact match */
+				match = i;
+				ambiguous = 0;
+				break;
+			}
+			if (match == -1)		/* partial match */
+				match = i;
+			else if (!IDENTICAL_INTERPRETATION(i, match))
+				ambiguous = 1;
+		}
+		if (ambiguous) {
+			/* ambiguous abbreviation */
+			if (PRINT_ERROR)
+				warnx(ambig, (int)current_argv_len,
+					current_argv);
+			optopt = 0;
+			return BADCH;
+		}
+		if (match != -1) {			/* option found */
+			if (long_options[match].has_arg == no_argument
+				&& has_equal) {
+				if (PRINT_ERROR)
+					warnx(noarg, (int)current_argv_len,
+						current_argv);
+				/*
+				 * XXX: GNU sets optopt to val regardless of
+				 * flag
+				 */
+				if (long_options[match].flag == NULL)
+					optopt = long_options[match].val;
+				else
+					optopt = 0;
+				return BADARG;
+			}
+			if (long_options[match].has_arg == required_argument ||
+				long_options[match].has_arg == optional_argument) {
+				if (has_equal)
+					optarg = has_equal;
+				else if (long_options[match].has_arg ==
+					required_argument) {
+					/*
+					 * optional argument doesn't use
+					 * next nargv
+					 */
+					optarg = nargv[optind++];
+				}
+			}
+			if ((long_options[match].has_arg == required_argument)
+				&& (optarg == NULL)) {
+				/*
+				 * Missing argument; leading ':'
+				 * indicates no error should be generated
+				 */
+				if (PRINT_ERROR)
+					warnx(recargstring, current_argv);
+				/*
+				 * XXX: GNU sets optopt to val regardless
+				 * of flag
+				 */
+				if (long_options[match].flag == NULL)
+					optopt = long_options[match].val;
+				else
+					optopt = 0;
+				--optind;
+				return BADARG;
+			}
+		}
+		else {			/* unknown option */
+			if (PRINT_ERROR)
+				warnx(illoptstring, current_argv);
+			optopt = 0;
+			return BADCH;
+		}
+		if (long_options[match].flag) {
+			*long_options[match].flag = long_options[match].val;
+			retval = 0;
+		}
+		else
+			retval = long_options[match].val;
+		if (idx)
+			*idx = match;
+	}
+	return retval;
+#undef IDENTICAL_INTERPRETATION
+}

--- a/unistd/getopt.h
+++ b/unistd/getopt.h
@@ -5,11 +5,14 @@
 #ifndef getopt_h
 #define getopt_h
 
-int getopt(int argc, char *const argv[],
+#include "cfunc.h"
+
+CFUNC int getopt(int argc, char *const argv[],
 		  const char *optstring);
 
-extern const char *optarg;
-extern int optind, opterr, optopt;
+CFUNC const char *optarg;
+CFUNC int optind, opterr, optopt;
+enum  	getopt_argument_requirement { no_argument = 0, required_argument = 1, optional_argument = 2 };
 
 struct option {
 	   const char *name;
@@ -18,11 +21,11 @@ struct option {
 	   int         val;
    };
 
-int getopt_long(int argc, char *const argv[],
+CFUNC int getopt_long(int argc, char *const argv[],
 		  const char *optstring,
 		  const struct option *longopts, int *longindex);
 		  
-int getopt_long_only(int argc, char *const argv[],
+CFUNC int getopt_long_only(int argc, char *const argv[],
 		  const char *optstring,
 		  const struct option *longopts, int *longindex);
 		  

--- a/unistd/sources.cmake
+++ b/unistd/sources.cmake
@@ -34,6 +34,7 @@ clock_gettime.cpp
 dirent.cpp
 fnmatch.cpp
 fts.c
+getline.cpp
 getopt.cpp
 gettimeofday.cpp
 netdb.c

--- a/unistd/unistd.h
+++ b/unistd/unistd.h
@@ -164,6 +164,9 @@ CFUNC int ftruncate(int fd, off_t length);
 CFUNC int fseeko(FILE *stream, off_t offset, int whence);
 CFUNC off_t ftello(FILE *stream);
 CFUNC char* strptime(const char* s, const char* format,struct tm* tm);
+CFUNC ssize_t getline(char** lineptr, size_t* n, FILE* stream);
+CFUNC ssize_t getdelim(char** lineptr, size_t* n, int delim, FILE* stream);
+
 CFUNC ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
 CFUNC int setlinebuf(FILE *stream);
 CFUNC int vasprintf(char **strp, const char *fmt, va_list ap);


### PR DESCRIPTION
I'm moving zeek-cut out of zeek-aux into zeek/tools so it can be used by Windows. This means needing a couple of additional functions in libunistd: `getline()` and `getopt()`.

Related to https://github.com/zeek/zeek/pull/5239