### PR TITLE
Remove unnecessary User32.lib linkage from Finder.h

### DIFF
--- a/portable/Finder.h
+++ b/portable/Finder.h
@@ -14,8 +14,6 @@
 #include <strsafe.h>
 #include <string>
 
-#pragma comment(lib, "User32.lib")
-
 #define WIN_NO_ERROR 0 // WIN_NO_ERROR = NO_ERROR As we are undeffing `NO_ERROR` to avoid naming collision in unistd.h
 
 namespace portable {


### PR DESCRIPTION
 Finder.h only uses Win32 file-system APIs (FindFirstFile,
 FindNextFile, FindClose) which are provided by kernel32.dll.
 The #pragma comment(lib, "User32.lib") was not needed.