### PR TITLE
Require a newer version of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # libunistd/CMakeList.txt
 
-cmake_minimum_required (VERSION 3.0.0)
+cmake_minimum_required (VERSION 3.15.0)
 project(libunistd)
 message("<<< Parsing libunistd/CMakeList.txt")
 message("--- Building ${PROJECT_NAME} ${CMAKE_SYSTEM_NAME}:${CMAKE_HOST_SYSTEM_PROCESSOR}:${CMAKE_GENERATOR_TOOLSET} ---")


### PR DESCRIPTION
The CMake version that comes with Visual Studio 2026 doesn't allow requiring CMake 3.0 anymore. This updates the required version to 3.15.0, which matches Zeek's requirement.